### PR TITLE
Make toString() safe for php 7.2

### DIFF
--- a/src/LaravelCsvGenerator.php
+++ b/src/LaravelCsvGenerator.php
@@ -55,6 +55,8 @@ class LaravelCsvGenerator
 
     public function toString(): string
     {
+        $res = '';
+        
         foreach ($this->data as $record) {
             $res .= '"' . implode('","', $record) . '"' . "\n";
         }


### PR DESCRIPTION
prevents "[ErrorException] Undefined variable: res"